### PR TITLE
Properly check for bitten in CheckForGameEnd()

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -3503,7 +3503,8 @@ namespace Werewolf_Node
 
             if (alivePlayers.All(x => !WolfRoles.Contains(x.PlayerRole) && x.PlayerRole != IRole.Cultist && x.PlayerRole != IRole.SerialKiller)) //checks for cult and SK are actually useless...
                 //no wolf, no cult, no SK... VG wins!
-                return DoGameEnd(ITeam.Village);
+                if (!checkbitten || alivePlayers.All(x => !x.Bitten)) //unless bitten is about to turn into a wolf
+                    return DoGameEnd(ITeam.Village);
 
 
             return false;


### PR DESCRIPTION
CheckForGameEnd() only tested for a player bitten by the Alpha Wolf if there is a traitor, otherwise the game would end prematurely.